### PR TITLE
fixed redirect

### DIFF
--- a/app/cain/settings.py
+++ b/app/cain/settings.py
@@ -145,8 +145,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
-LOGIN_REDIRECT_URL = '/blog/'
-ACCOUNT_LOGOUT_REDIRECT_URL = '/blog/'
+#LOGIN_REDIRECT_URL = '/blog/'
+#ACCOUNT_LOGOUT_REDIRECT_URL = '/blog/'
 
 SESSION_COOKIE_DOMAIN = '.' + SITE_DOMAIN_NO_PORT
 CSRF_COOKIE_DOMAIN = '.' + SITE_DOMAIN_NO_PORT  # Enables sharing csrf-tokens with subdomains

--- a/app/deckard/context_processors.py
+++ b/app/deckard/context_processors.py
@@ -1,5 +1,9 @@
 # this adds {{ test }} to every context so it can be used in a template
+from cain.settings import SITE_DOMAIN, SITE_PREFIX
 
 
 def custom_context(request):
-    return {'test': 'custom context works'}
+    return {
+        'domain': SITE_DOMAIN,
+        'prefix': SITE_PREFIX,
+    }

--- a/app/deckard/templates/jinja2/deckard/login_link.html
+++ b/app/deckard/templates/jinja2/deckard/login_link.html
@@ -4,13 +4,13 @@
                            data-placement="auto"
                            data-trigger="focus"
                            data-title="Выберите способ авторизации"
-                           data-content="<a class='dkr-icon-link' href='/accounts/vk/login?next={{ request.path }}'>
+                           data-content="<a class='dkr-icon-link' href='{{ prefix }}{{ domain }}/accounts/vk/login?next=/redir%3Furl={{ request.build_absolute_uri() }}'>
                                       <span class='fa-stack'>
                                          <i class='fa fa-square fa-stack-2x dkr-colored-icon'></i>
                                          <i class='fa fa-vk fa-stack-1x fa-inverse'></i>
                                       </span>
                                       </a>
-                                      <a class='dkr-icon-link' href='/accounts/facebook/login?next={{ request.path }}'>
+                                      <a class='dkr-icon-link' href='{{ prefix }}{{ domain }}/accounts/facebook/login?next=/redir%3Furl={{ request.build_absolute_uri() }}'>
                                       <span class='fa-stack'>
                                          <i class='fa fa-square fa-stack-2x dkr-colored-icon'></i>
                                          <i class='fa fa-facebook fa-stack-1x fa-inverse'></i>

--- a/app/deckard/templatetags/filters.py
+++ b/app/deckard/templatetags/filters.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 import re
 from django import template
 import mistune
@@ -65,3 +65,12 @@ def addcss(field, css):
     class_old = field.field.widget.attrs.get("class", None)
     class_new = class_old + ' ' + css if class_old else css
     return field.as_widget(attrs={"class": class_new})
+
+
+@register.filter(name='urlencode')
+def urlencode(uri, **query):
+    parts = list(urlparse(uri))
+    q = parse_qs(parts[4])
+    q.update(query)
+    parts[4] = urlencode(q)
+    return urlunparse(parts)

--- a/app/deckard/urls.py
+++ b/app/deckard/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     url(r'^post/' + POST_SLUG_RE + r'/repost/$', views.repost, name='repost'),
     url(r'^post/' + POST_SLUG_RE + r'/rate/(?P<rating_sign>plus|minus)/$', views.rate_post, name='rate_post'),
     url(r'^comment/' + COMMENT_RE + r'/rate/(?P<rating_sign>plus|minus)/$', views.rate_comment, name='rate_comment'),
+    url(r'^redir/', views.redir, name='redir'),
 ]

--- a/app/deckard/views.py
+++ b/app/deckard/views.py
@@ -327,3 +327,9 @@ def toggle_comment(request, post_id, slug):
         })
 
     return HttpResponseRedirect("{}#c{}".format(url, comment_id))
+
+
+def redir(request):
+    if request.GET.get("url"):
+        return HttpResponseRedirect(request.GET.get("url"))
+    raise Http404("Redirect error")


### PR DESCRIPTION
Now there's specific /redir location allowing facebook to redirect user after login to root domain, and we redirect him to second level domain because of ?url= parameter.

urlencode filter has no needs, but may be useful in future.

fixing #98